### PR TITLE
Initial CI packaging and documentation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,247 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  WASMEDGE_VERSION: "0.14.1"
+
+jobs:
+  build_ubuntu:
+    name: build-ubuntu
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        arch: [x86_64]
+        rust: [stable]
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_LABEL: moly-server-${{ matrix.os }}-${{ matrix.arch }}
+      DIST_DIR: ${{ github.workspace }}/dist/moly-server-${{ matrix.os }}-${{ matrix.arch }}
+      RUST_TARGET: ${{ matrix.arch }}-unknown-linux-gnu
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install WasmEdge (${{ env.WASMEDGE_VERSION }})
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version="$WASMEDGE_VERSION"
+          source "$HOME"/.wasmedge/env
+          echo "WASMEDGE_DIR=$HOME/.wasmedge" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ env.RUST_TARGET }}
+
+      - name: Rust cache
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'dev' }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ env.BUILD_LABEL }}
+
+      - name: cargo build
+        run: |
+          cargo build --locked --release --bin=moly-server --target="$RUST_TARGET" --target-dir=target --features reqwest/native-tls-vendored
+
+      - name: Set up build/dist directories
+        run: |
+          rm -rf "$DIST_DIR"
+          mkdir -p "$DIST_DIR"
+
+      - name: Copy WasmEdge libraries
+        run: |
+          shopt -s extglob
+          mkdir -p "$DIST_DIR"/lib
+          cp "$WASMEDGE_DIR"/lib/libwasmedge.so.+([^.]) "$DIST_DIR"/lib/
+          cp "$WASMEDGE_DIR"/plugin/libwasmedgePluginWasiNN.so "$DIST_DIR"/lib/
+
+      - name: Copy binary artifacts
+        run: |
+          mkdir -p "$DIST_DIR"/bin
+          cp "target/$RUST_TARGET/release/moly-server" "$DIST_DIR"/bin/
+
+      - name: Copy resource files
+        run: |
+          cp LICENSE "$DIST_DIR"/
+
+      - name: Strip unneeded binary symbols
+        run: |
+          strip \
+              --strip-unneeded \
+              --remove-section=.comment \
+              --remove-section=.note \
+              "$DIST_DIR"/bin/moly-server
+
+      - name: Patch binary with relative rpath
+        run: |
+          patchelf --set-rpath '$ORIGIN/../lib' "$DIST_DIR"/bin/moly-server
+
+      - name: Upload dist archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_LABEL }}
+          path: ${{ env.DIST_DIR }}
+
+  build_macos:
+    name: build-macos
+    strategy:
+      matrix:
+        os: [macos-14]
+        arch: [x86_64, aarch64]
+        rust: [stable]
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_LABEL: moly-server-darwin-${{ matrix.arch }}
+      DIST_DIR: ${{ github.workspace }}/dist/moly-server-darwin-${{ matrix.arch }}
+      RUST_TARGET: ${{ matrix.arch }}-apple-darwin
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install WasmEdge (${{ env.WASMEDGE_VERSION }})
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version="$WASMEDGE_VERSION" --arch=${{ matrix.arch }}
+          source "$HOME"/.wasmedge/env
+          echo "WASMEDGE_DIR=$HOME/.wasmedge" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ env.RUST_TARGET }}
+
+      - name: Rust cache
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'dev' }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ env.BUILD_LABEL }}
+
+      - name: cargo build
+        run: |
+          cargo build --locked --release --bin=moly-server --target="$RUST_TARGET" --target-dir=target
+
+      - name: Set up build/dist directories
+        run: |
+          rm -rf "$DIST_DIR"
+          mkdir -p "$DIST_DIR"
+
+      - name: Copy WasmEdge libraries
+        run: |
+          shopt -s extglob
+          mkdir -p "$DIST_DIR"/lib
+          cp "$WASMEDGE_DIR"/lib/libwasmedge.+([^.]).dylib "$DIST_DIR"/lib/
+          cp "$WASMEDGE_DIR"/plugin/libwasmedgePluginWasiNN.dylib "$DIST_DIR"/lib/
+
+      - name: Copy binary artifacts
+        run: |
+          mkdir -p "$DIST_DIR"/bin
+          cp "target/$RUST_TARGET/release/moly-server" "$DIST_DIR"/bin/
+
+      - name: Copy resource files
+        run: |
+          cp LICENSE "$DIST_DIR"/
+
+      - name: Patch binary with relative rpath
+        run: |
+          install_name_tool -add_rpath '@executable_path/../lib' "$DIST_DIR"/bin/moly-server
+
+      - name: Upload dist archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_LABEL }}
+          path: ${{ env.DIST_DIR }}
+
+  build_windows:
+    name: build-windows
+    strategy:
+      matrix:
+        os: [windows-2022]
+        rust: [stable]
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_LABEL: moly-server-windows-x86_64
+      DIST_DIR: ${{ github.workspace }}\dist\moly-server-windows-x86_64
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install WasmEdge (${{ env.WASMEDGE_VERSION }})
+        run: |
+          $wasmedge_release_url = "https://github.com/WasmEdge/WasmEdge/releases/download/$env:WASMEDGE_VERSION"
+
+          $wasmedge_dist = "WasmEdge-$env:WASMEDGE_VERSION-windows" ## directory is `WasmEdge-X.Y.Z-Windows`--case insensitivity matters
+          $wasi_nn_dist = "WasmEdge-plugin-wasi_nn-ggml-noavx-$env:WASMEDGE_VERSION-windows_x86_64"
+
+          $ProgressPreference = 'SilentlyContinue'  ## makes downloads much faster
+
+          Invoke-WebRequest -Uri "$wasmedge_release_url/${wasmedge_dist}.zip" -OutFile "$env:TEMP\${wasmedge_dist}.zip"
+          Expand-Archive -Force -LiteralPath "$env:TEMP\${wasmedge_dist}.zip" -DestinationPath "${{ github.workspace }}"
+
+          Invoke-WebRequest -Uri "$wasmedge_release_url/${wasi_nn_dist}.zip" -OutFile "$env:TEMP\${wasi_nn_dist}.zip"
+          Expand-Archive -Force -LiteralPath "$env:TEMP\${wasi_nn_dist}.zip" -DestinationPath "$env:TEMP"
+          Copy-Item -Recurse -Force -Path "$env:TEMP\$wasi_nn_dist\lib\wasmedge\*" -Destination "${{ github.workspace }}\$wasmedge_dist\lib"
+
+          $ProgressPreference = 'Continue' ## restore default progress bars
+
+          echo "WASMEDGE_DIR=${{ github.workspace }}\$wasmedge_dist" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+      - name: Set up Windows 10 SDK
+        uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+        with:
+          sdk-version: 20348
+
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Rust cache
+        if: ${{ github.head_ref != 'main' && github.head_ref != 'dev' }}
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ env.BUILD_LABEL }}
+
+      - name: cargo build
+        run: |
+          cargo build --locked --release --bin=moly-server
+
+      - name: Set up build/dist directories
+        shell: bash
+        run: |
+          rm -rf "$DIST_DIR"
+          mkdir -p "$DIST_DIR"
+
+      - name: Copy WasmEdge libraries
+        shell: bash
+        run: |
+          mkdir -p "$DIST_DIR"/lib
+          cp "$WASMEDGE_DIR"/bin/wasmedge.dll "$DIST_DIR"/
+          cp "$WASMEDGE_DIR"/lib/wasmedgePluginWasiNN.dll "$DIST_DIR"/
+
+      - name: Copy binary artifacts
+        shell: bash
+        run: |
+          mkdir -p "$DIST_DIR"/bin
+          cp target/release/moly-server "$DIST_DIR"/
+
+      - name: Copy resource files
+        shell: bash
+        run: |
+          cp LICENSE "$DIST_DIR"/
+
+      - name: Upload dist archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_LABEL }}
+          path: ${{ env.DIST_DIR }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - dev
     paths-ignore:
       - "**/*.md"
   pull_request:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,84 @@ A local HTTP server that powers the Moly app by providing capabilities for searc
 
 ## Building and Running
 
-> ⚠️ **Note**: TODO
+1. [Install Rust](https://www.rust-lang.org/tools/install).
+
+2. Obtain the source code for this repository:
+
+```sh
+git clone https://github.com/moxin-org/moly-server.git
+```
+
+3. Follow the platform-specific instructions below.
+
+### macOS
+
+Install the required WasmEdge WASM runtime:
+
+```sh
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
+
+source $HOME/.wasmedge/env
+```
+
+Then use `cargo` to build and run the server:
+
+```sh
+cd moly-server
+cargo run -p moly-server
+```
+
+### Linux
+
+Install the required WasmEdge WASM runtime:
+
+```sh
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.1
+
+source $HOME/.wasmedge/env
+```
+
+> [!IMPORTANT]
+> If your CPU does not support AVX512, then you should append the `--noavx` option onto the above command.
+
+To build Moly on Linux, you must install the following dependencies: `openssl`,
+`clang`/`libclang`, `binfmt`. On a Debian-like Linux distro (e.g., Ubuntu), run
+the following:
+
+```sh
+sudo apt-get update
+sudo apt-get install libssl-dev pkg-config llvm clang libclang-dev binfmt-support
+```
+
+Then use `cargo` to build and run the Moly server:
+
+```sh
+cd moly-server
+cargo run -p moly-server
+```
+
+## Windows (Windows 10, Windows 11 or higher)
+
+1. Install the required WasmEdge WASM runtime from the WasmEdge releases page:
+   [`WasmEdge-0.14.1-windows.msi`](https://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-0.14.1-windows.msi)
+
+2. Download and extract the appropriate WASI-NN/GGML plugin for your system:
+
+    - For CUDA 11/12:
+      [`WasmEdge-plugin-wasi_nn-ggml-cuda-0.14.1-windows-x86_64.zip`](https://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-plugin-wasi_nn-ggml-cuda-0.14.1-windows_x86_64.zip)
+    - For CPUs with AVX512 support:
+      [`WasmEdge-plugin-wasi_nn-ggml-0.14.1-windows-x86_64.zip`](ttps://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-plugin-wasi_nn-ggml-0.14.1-windows_x86_64.zip)
+    - Otherwise:
+      [`WasmEdge-plugin-wasi_nn-ggml-noavx-0.14.1-windows-x86_64.zip`](ttps://github.com/WasmEdge/WasmEdge/releases/download/0.14.1/WasmEdge-plugin-wasi_nn-ggml-noavx-0.14.1-windows_x86_64.zip)
+
+3. Copy the plugin DLL from that archive `.\lib\wasmedge\wasmedgePluginWasiNN.dll` to `Program Files\WasmEdge\lib\`
+
+4. Then use `cargo` to build and run the Moly server:
+
+    ```sh
+    cd moly-server
+    cargo run -p moly-server
+    ```
 
 ## Development
 


### PR DESCRIPTION
## Summary

This PR adds basic support for tarball-style distribution across Ubuntu (Linux), macOS, and Windows for testing during development. In addition, build documentation has been added to the README ([rendered](https://github.com/cass-uredium/moly-server/blob/ci/README.md)), adapted from Moly.

The following artifacts are now uploaded at the end of a CI run:

- `moly-server-darwin-aarch64`
- `moly-server-darwin-x86_64`
- `moly-server-ubuntu-22.04-x86_64`
- `moly-server-windows-x86_64`

## Changes

Differences from Moly build process:

- Cache Rust artifacts (target dir, `~/.cargo`, etc.)--currently, this is mostly minimal to avoid frequent breakage, although more aggressive caching with fallback is possible.
- Build on Rust stable rather than MSRV, to be re-introduced in a subsequent PR with test/linting support.
- macOS: build for x86_64 in addition to aarch64; add similar but unused support for Ubuntu
- Ubuntu: remove `Xcursor`/`X11`, `asound`/`pulse` system dependencies

## Review

~~`README.md.diff` contains the diff between [`moly/README.md`](https://github.com/moxin-org/moly/blob/dev/README.md) and [`moly-server/README.md`](https://github.com/moxin-org/moly-server/blob/main/README.md). This file will be removed after review.~~ (edit: removed)

Previous workflow runs: <https://github.com/cass-uredium/moly-server/actions>

<details><summary><b>Archive details</b></summary>
<h4>moly-server-darwin-aarch64</h4>
<pre>
moly-server-darwin-aarch64/
├── LICENSE
├── bin/
│   └── moly-server*
└── lib/
    ├── libwasmedge.0.dylib*
    └── libwasmedgePluginWasiNN.dylib*
&nbsp;
181M	(3 directories, 4 files)
</pre>
<h4>moly-server-darwin-x86_64</h4>
<pre>
moly-server-darwin-x86_64/
├── LICENSE
├── bin/
│   └── moly-server*
└── lib/
    ├── libwasmedge.0.dylib*
    └── libwasmedgePluginWasiNN.dylib*
&nbsp;
205M	(3 directories, 4 files)
</pre>
<h4>moly-server-ubuntu-22.04-x86_64</h4>
<pre>
moly-server-ubuntu-22.04-x86_64/
├── LICENSE
├── bin/
│   └── moly-server*
└── lib/
    ├── libwasmedge.so.0
    └── libwasmedgePluginWasiNN.so*
&nbsp;
111M	(3 directories, 4 files)
</pre>
<h4>moly-server-windows-x86_64</h4>
<pre>
moly-server-windows-x86_64/
├── LICENSE
├── moly-server.exe
├── wasmedge.dll
└── wasmedgePluginWasiNN.dll
&nbsp;
70M	(1 directory, 4 files)
</pre>
</details>

## To-do

- [x] Remove `README.md.diff`.
- [x] ~~Determine Windows installation procedure (see comments).~~

## Future work

- Moly/organizational build tooling:
  - Upload CI artifacts to releases, etc.
  - Reflect these changes in `moly/switch-to-http`--largely removing/extracting as a first step.
  - Explore adapting convenience tools like `moly-runner` to the new client/server architecture.
- Full packaging support:
  - Use cargo-packager to generate .deb, .dmg (?), .exe/.msi, etc.
- Extended build support:
  - Ubuntu 20.04, 24.04 and other system versions (trivial change, just adds CI minutes)
  - WasmEdge with CUDA 11/12, noavx (this may just be a packaging difference)
  - Build for RHEL derivatives (e.g. Fedora)--requires cargo-packager support
- Additional CI/CD:
  - Add basic testing and linting.
    - See <https://nexte.st/docs/ci-features/archiving/>.
  - Add expanded integration testing between moly-app/moly-server.
  - Re-add builds against MSRV 1.79.
  
### Misc. notes

- This workflow could eventually be split into separate build/packaging steps to be depended on by test/lint steps, etc., caching/transferring intermediate artifacts where possible. As this is currently the only CI workflow, it's run on every branch for every push.