### PR TITLE
Proper support for OpenAI /completions and /models

### DIFF
--- a/moly-protocol/src/open_ai.rs
+++ b/moly-protocol/src/open_ai.rs
@@ -154,3 +154,17 @@ pub enum ChatResponse {
     // https://platform.openai.com/docs/api-reference/chat/streaming
     ChatResponseChunk(ChatResponseChunkData),
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ModelsResponse {
+    pub object: String,
+    pub data: Vec<OpenAIModel>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OpenAIModel {
+    pub id: String,
+    pub object: String,
+    pub created: u32,
+    pub owned_by: String,
+}


### PR DESCRIPTION
- Implemented api/v1/models to list available models in the OpenAI API format.
- Updated chat_completions to manage model loading automatically.