### PR TITLE
Consistent camel case

### DIFF
--- a/moly-local/src/backend_impls/api_server.rs
+++ b/moly-local/src/backend_impls/api_server.rs
@@ -52,8 +52,8 @@ fn create_wasi(
     };
 
     let n_gpu_layers = match load_model.gpu_layers {
-        moly_protocol::protocol::GPULayers::Specific(n) => Some(n.to_string()),
-        moly_protocol::protocol::GPULayers::Max => None,
+        moly_protocol::protocol::GpuLayers::Specific(n) => Some(n.to_string()),
+        moly_protocol::protocol::GpuLayers::Max => None,
     };
 
     // Set n_batch to a fixed value of 128.
@@ -236,12 +236,15 @@ impl BackendModel for LLamaEdgeApiServer {
         };
 
         if !need_reload {
-            return Ok((old_model.unwrap(), LoadModelResponse::Completed(LoadedModelInfo {
-                file_id: file.id.to_string(),
-                model_id: file.model_id,
-                information: "".to_string(),
-                listen_port: listen_addr.port(),
-            })));
+            return Ok((
+                old_model.unwrap(),
+                LoadModelResponse::Completed(LoadedModelInfo {
+                    file_id: file.id.to_string(),
+                    model_id: file.model_id,
+                    information: "".to_string(),
+                    listen_port: listen_addr.port(),
+                }),
+            ));
         }
 
         // Only stop the old model if it is not failed
@@ -268,7 +271,7 @@ impl BackendModel for LLamaEdgeApiServer {
             run_wasm_by_downloaded_file(listen_addr, wasm_module_, file, options, embedding_)
         });
 
-        // TODO: this entire approach to testing the server is too hacky. 
+        // TODO: this entire approach to testing the server is too hacky.
         // We need a better solution for this.
 
         // Give the server a moment to start up
@@ -310,17 +313,21 @@ impl BackendModel for LLamaEdgeApiServer {
                 failed: false,
             };
 
-            Ok((new_model, LoadModelResponse::Completed(LoadedModelInfo {
-                file_id: file_.id.to_string(),
-                model_id: file_.model_id,
-                information: "".to_string(),
-                listen_port: listen_addr.port(),
-            })))
+            Ok((
+                new_model,
+                LoadModelResponse::Completed(LoadedModelInfo {
+                    file_id: file_.id.to_string(),
+                    model_id: file_.model_id,
+                    information: "".to_string(),
+                    listen_port: listen_addr.port(),
+                }),
+            ))
         } else {
-
             // Cleanup the spawned task if we failed to connect
             model_thread.abort();
-            Err(anyhow!("Failed to start the model: Server did not respond after multiple attempts"))
+            Err(anyhow!(
+                "Failed to start the model: Server did not respond after multiple attempts"
+            ))
         }
     }
 
@@ -353,9 +360,11 @@ impl BackendModel for LLamaEdgeApiServer {
             };
 
             let Some(resp) = resp else {
-                let _ = tx.send(Ok(ChatResponse::ChatResponseChunk(stop_chunk(
-                    StopReason::Stop,
-                )))).await;
+                let _ = tx
+                    .send(Ok(ChatResponse::ChatResponseChunk(stop_chunk(
+                        StopReason::Stop,
+                    ))))
+                    .await;
                 return;
             };
 
@@ -368,14 +377,17 @@ impl BackendModel for LLamaEdgeApiServer {
                             match chunk {
                                 Ok(chunk) => {
                                     if chunk.starts_with(b"data: [DONE]") {
-                                        let _ = tx.send(Ok(ChatResponse::ChatResponseChunk(stop_chunk(
-                                            StopReason::Stop,
-                                        )))).await;
+                                        let _ = tx
+                                            .send(Ok(ChatResponse::ChatResponseChunk(stop_chunk(
+                                                StopReason::Stop,
+                                            ))))
+                                            .await;
                                         break;
                                     }
                                     let resp: Result<ChatResponseChunkData, anyhow::Error> =
                                         serde_json::from_slice(&chunk[5..]).map_err(|e| anyhow!(e));
-                                    let _ = tx.send(resp.map(ChatResponse::ChatResponseChunk)).await;
+                                    let _ =
+                                        tx.send(resp.map(ChatResponse::ChatResponseChunk)).await;
                                 }
                                 Err(e) => {
                                     let _ = tx.send(Err(anyhow!(e))).await;
@@ -385,7 +397,12 @@ impl BackendModel for LLamaEdgeApiServer {
                         }
                     } else {
                         let resp = resp.json::<ChatResponseData>().await;
-                        let _ = tx.send(resp.map(ChatResponse::ChatFinalResponseData).map_err(|e| anyhow!(e))).await;
+                        let _ = tx
+                            .send(
+                                resp.map(ChatResponse::ChatFinalResponseData)
+                                    .map_err(|e| anyhow!(e)),
+                            )
+                            .await;
                     }
                 }
                 Err(e) => {

--- a/moly-local/src/backend_impls/api_server.rs
+++ b/moly-local/src/backend_impls/api_server.rs
@@ -20,7 +20,7 @@ use super::BackendModel;
 static WASM: &[u8] = include_bytes!("../../wasm/llama-api-server.wasm");
 
 /// Use server which is OpenAI compatible
-pub struct LLamaEdgeApiServer {
+pub struct LlamaEdgeApiServer {
     id: String,
     listen_addr: SocketAddr,
     load_model_options: LoadModelOptions,
@@ -179,7 +179,7 @@ fn stop_chunk(reason: StopReason) -> ChatResponseChunkData {
     }
 }
 
-impl BackendModel for LLamaEdgeApiServer {
+impl BackendModel for LlamaEdgeApiServer {
     async fn new_or_reload(
         old_model: Option<Self>,
         file: crate::store::download_files::DownloadedFile,

--- a/moly-local/src/backend_impls/chat_ui.rs
+++ b/moly-local/src/backend_impls/chat_ui.rs
@@ -326,8 +326,8 @@ fn create_wasi(
     };
 
     let n_gpu_layers = match load_model.gpu_layers {
-        moly_protocol::protocol::GPULayers::Specific(n) => Some(n.to_string()),
-        moly_protocol::protocol::GPULayers::Max => None,
+        moly_protocol::protocol::GpuLayers::Specific(n) => Some(n.to_string()),
+        moly_protocol::protocol::GpuLayers::Max => None,
     };
 
     // Set n_batch to a fixed value of 128.

--- a/moly-local/src/backend_impls/mod.rs
+++ b/moly-local/src/backend_impls/mod.rs
@@ -33,7 +33,7 @@ pub enum DownloadControlCommand {
 
 // TODO: Should we just remove ChatBotModel? is not being used anywhere
 // pub type ChatModelBackend = BackendImpl<chat_ui::ChatBotModel>;
-pub type LlamaEdgeApiServerBackend = BackendImpl<api_server::LLamaEdgeApiServer>;
+pub type LlamaEdgeApiServerBackend = BackendImpl<api_server::LlamaEdgeApiServer>;
 
 pub trait BackendModel: Sized {
     /// Creates a new model or reloads an existing one.

--- a/moly-local/src/backend_impls/mod.rs
+++ b/moly-local/src/backend_impls/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use chrono::Utc;
 use moly_protocol::{
     data::{DownloadedFile, FileId, PendingDownload},
-    open_ai::{ChatRequestData, ChatResponse, ModelsResponse, OpenAIModel},
+    open_ai::{ChatRequestData, ChatResponse, ModelsResponse, OpenAiModel},
     protocol::{FileDownloadResponse, LoadModelOptions, LoadModelResponse},
 };
 use tokio::sync::{
@@ -279,7 +279,7 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
         let default_opts = LoadModelOptions {
             override_server_address: None,
             prompt_template: None,
-            gpu_layers: moly_protocol::protocol::GPULayers::Max,
+            gpu_layers: moly_protocol::protocol::GpuLayers::Max,
             use_mlock: false,
             rope_freq_scale: 0.0,
             rope_freq_base: 0.0,
@@ -398,7 +398,7 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
             object: "list".to_string(),
             data: files
                 .into_iter()
-                .map(|file| OpenAIModel {
+                .map(|file| OpenAiModel {
                     id: file.file.id,
                     object: "model".to_string(),
                     created: file.downloaded_at.timestamp() as u32,

--- a/moly-local/src/backend_impls/mod.rs
+++ b/moly-local/src/backend_impls/mod.rs
@@ -1,18 +1,19 @@
 use std::{
-    collections::HashMap, path::{Path, PathBuf}, sync::{
-        Arc, Mutex,
-    }
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
 use chrono::Utc;
 use moly_protocol::{
-    data::{DownloadedFile, FileID, PendingDownload},
+    data::{DownloadedFile, FileId, PendingDownload},
     open_ai::{ChatRequestData, ChatResponse, ModelsResponse, OpenAIModel},
-    protocol::{
-        FileDownloadResponse, LoadModelOptions, LoadModelResponse
-    },
+    protocol::{FileDownloadResponse, LoadModelOptions, LoadModelResponse},
 };
-use tokio::sync::{mpsc::{UnboundedSender, Sender, Receiver}, RwLock};
+use tokio::sync::{
+    mpsc::{Receiver, Sender, UnboundedSender},
+    RwLock,
+};
 
 use crate::store::{
     self,
@@ -21,13 +22,13 @@ use crate::store::{
 };
 
 mod api_server;
-// Commenting out this implementation as it is not being used anywhere and requires 
+// Commenting out this implementation as it is not being used anywhere and requires
 // a lot of reworking to be used with the http server.
 // mod chat_ui;
 
 #[derive(Debug, Clone)]
 pub enum DownloadControlCommand {
-    Stop(FileID),
+    Stop(FileId),
 }
 
 // TODO: Should we just remove ChatBotModel? is not being used anywhere
@@ -82,7 +83,11 @@ pub struct BackendImpl<Model: BackendModel> {
 
 impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
     /// Builds a backend instance by initializing the model indexes and the file downloader.
-    pub async fn build<A: AsRef<Path>, M: AsRef<Path>>(app_data_dir: A, models_dir: M, max_download_threads: usize) -> Self {
+    pub async fn build<A: AsRef<Path>, M: AsRef<Path>>(
+        app_data_dir: A,
+        models_dir: M,
+        max_download_threads: usize,
+    ) -> Self {
         let app_data_dir = app_data_dir.as_ref().to_path_buf();
 
         log::info!("build by app_data_dir: {:?}", app_data_dir);
@@ -120,8 +125,13 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
 
         {
             let client = reqwest::Client::new();
-            let downloader =
-                ModelFileDownloader::new(client, sql_conn.clone(), control_tx.clone(), model_indexs.country_code.clone(), 0.1);
+            let downloader = ModelFileDownloader::new(
+                client,
+                sql_conn.clone(),
+                control_tx.clone(),
+                model_indexs.country_code.clone(),
+                0.1,
+            );
 
             tokio::spawn(ModelFileDownloader::run_loop(
                 downloader,
@@ -152,13 +162,14 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
                 .split_once("#")
                 .ok_or_else(|| anyhow::anyhow!("Illegal file_id"))?;
 
-            let index = self.model_indexs
+            let index = self
+                .model_indexs
                 .get_index_by_id(model_id)
                 .ok_or(anyhow::anyhow!("No model found"))?
                 .clone();
-            
+
             let remote_model = self.model_indexs.load_model_card(&index)?;
-            
+
             let remote_file = remote_model
                 .files
                 .into_iter()
@@ -208,23 +219,25 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
 
         // Create a channel for progress updates that we'll handle with SSE later
         let (progress_tx, progress_rx) = tokio::sync::mpsc::channel(100);
-        self.download_progress.write().await.insert(file_id.clone(), progress_rx);
-        
+        self.download_progress
+            .write()
+            .await
+            .insert(file_id.clone(), progress_rx);
+
         // Start the download
-        self.download_tx.send((
-            model,
-            file.clone(),
-            remote_file,
-            progress_tx
-        ))?;
+        self.download_tx
+            .send((model, file.clone(), remote_file, progress_tx))?;
 
         Ok(())
     }
 
     /// Returns the progress channel for a given file ID.
-    pub async fn get_download_progress_channel(&mut self, file_id: String) 
-    -> anyhow::Result<Receiver<anyhow::Result<FileDownloadResponse>>> {
-        let rx = self.download_progress
+    pub async fn get_download_progress_channel(
+        &mut self,
+        file_id: String,
+    ) -> anyhow::Result<Receiver<anyhow::Result<FileDownloadResponse>>> {
+        let rx = self
+            .download_progress
             .write()
             .await
             .remove(&file_id) // TODO:(Julian) we should only remove the channel once the download is complete
@@ -239,10 +252,7 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
 
     pub fn delete_file(&self, file_id: String) -> Result<(), anyhow::Error> {
         store::download_files::DownloadedFile::remove(&file_id, &self.open_db_conn())?;
-        store::remove_downloaded_file(
-            self.models_dir.to_string_lossy().to_string(),
-            file_id,
-        )
+        store::remove_downloaded_file(self.models_dir.to_string_lossy().to_string(), file_id)
     }
 
     pub fn get_current_downloads(&self) -> Result<Vec<PendingDownload>, anyhow::Error> {
@@ -256,15 +266,16 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
     }
 
     pub fn cancel_download(&self, file_id: String) -> Result<(), anyhow::Error> {
-        self.control_tx.send(DownloadControlCommand::Stop(file_id.clone()))?;
+        self.control_tx
+            .send(DownloadControlCommand::Stop(file_id.clone()))?;
         store::download_files::DownloadedFile::remove(&file_id, &self.open_db_conn())?;
-        store::remove_downloaded_file(
-            self.models_dir.to_string_lossy().to_string(),
-            file_id,
-        )
+        store::remove_downloaded_file(self.models_dir.to_string_lossy().to_string(), file_id)
     }
 
-    pub async fn load_model_with_default_opts(&mut self, file_id: String) -> Result<LoadModelResponse, anyhow::Error> {
+    pub async fn load_model_with_default_opts(
+        &mut self,
+        file_id: String,
+    ) -> Result<LoadModelResponse, anyhow::Error> {
         let default_opts = LoadModelOptions {
             override_server_address: None,
             prompt_template: None,
@@ -279,7 +290,11 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
         self.load_model(file_id, default_opts).await
     }
 
-    pub async fn load_model(&mut self, file_id: String, options: LoadModelOptions) -> Result<LoadModelResponse, anyhow::Error> {
+    pub async fn load_model(
+        &mut self,
+        file_id: String,
+        options: LoadModelOptions,
+    ) -> Result<LoadModelResponse, anyhow::Error> {
         let download_file =
             store::download_files::DownloadedFile::get_by_id(&self.open_db_conn(), &file_id);
 
@@ -293,7 +308,8 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
                     file,
                     options,
                     self.model_indexs.embedding_model(),
-                ).await;
+                )
+                .await;
 
                 match result {
                     Ok((model, response)) => {
@@ -318,7 +334,9 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
         }
     }
 
-    pub fn get_featured_models(&mut self) -> Result<Vec<moly_protocol::data::Model>, anyhow::Error> {
+    pub fn get_featured_models(
+        &mut self,
+    ) -> Result<Vec<moly_protocol::data::Model>, anyhow::Error> {
         let res = self.model_indexs.get_featured_model(100, 0);
         match res {
             Ok(indexs) => {
@@ -340,7 +358,10 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
         }
     }
 
-    pub fn search_models(&mut self, search_text: String) -> Result<Vec<moly_protocol::data::Model>, anyhow::Error> {
+    pub fn search_models(
+        &mut self,
+        search_text: String,
+    ) -> Result<Vec<moly_protocol::data::Model>, anyhow::Error> {
         let res = self.model_indexs.search(&search_text, 100, 0);
         match res {
             Ok(indexs) => {
@@ -375,12 +396,15 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
 
         Ok(ModelsResponse {
             object: "list".to_string(),
-            data: files.into_iter().map(|file| OpenAIModel {
-                id: file.file.id,
-                object: "model".to_string(),
-                created: file.downloaded_at.timestamp() as u32,
-                owned_by: "moly".to_string(),
-            }).collect(),
+            data: files
+                .into_iter()
+                .map(|file| OpenAIModel {
+                    id: file.file.id,
+                    object: "model".to_string(),
+                    created: file.downloaded_at.timestamp() as u32,
+                    owned_by: "moly".to_string(),
+                })
+                .collect(),
         })
     }
 
@@ -389,7 +413,11 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
     //     self.models_dir = models_dir.as_ref().to_path_buf();
     // }
 
-    pub fn chat(&self, data: ChatRequestData, tx: tokio::sync::mpsc::Sender<anyhow::Result<ChatResponse>>) -> Result<(), anyhow::Error> {
+    pub fn chat(
+        &self,
+        data: ChatRequestData,
+        tx: tokio::sync::mpsc::Sender<anyhow::Result<ChatResponse>>,
+    ) -> Result<(), anyhow::Error> {
         if let Some(model) = &self.model {
             model.chat(data, tx);
             Ok(())

--- a/moly-local/src/store/mod.rs
+++ b/moly-local/src/store/mod.rs
@@ -6,7 +6,7 @@ pub mod model_cards;
 
 use std::path::Path;
 
-use moly_protocol::data::FileID;
+use moly_protocol::data::FileId;
 
 pub use remote::*;
 
@@ -140,7 +140,7 @@ pub fn get_all_pending_downloads(
     Ok(result)
 }
 
-pub fn remove_downloaded_file(models_dir: String, file_id: FileID) -> anyhow::Result<()> {
+pub fn remove_downloaded_file(models_dir: String, file_id: FileId) -> anyhow::Result<()> {
     let (model_id, file) = file_id
         .split_once("#")
         .ok_or_else(|| anyhow::anyhow!("Illegal file_id"))?;

--- a/moly-protocol/src/data.rs
+++ b/moly-protocol/src/data.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 
-pub type FileID = String;
-pub type ModelID = String;
+pub type FileId = String;
+pub type ModelId = String;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct File {
     #[serde(default)]
-    pub id: FileID,
+    pub id: FileId,
     pub name: String,
     pub size: String,
     pub quantization: String,
@@ -75,7 +75,7 @@ pub struct PendingDownload {
 // models sources are added.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct Model {
-    pub id: ModelID,
+    pub id: ModelId,
     pub name: String,
     pub summary: String,
     pub size: String,

--- a/moly-protocol/src/open_ai.rs
+++ b/moly-protocol/src/open_ai.rs
@@ -16,7 +16,7 @@ pub struct ChatRequestData {
 
     // Not really necessary but it is part of the OpenAI API. We are going to send the id
     // of the model currently loaded.
-    pub model: ModelID,
+    pub model: ModelId,
 
     pub frequency_penalty: Option<f32>,
     #[serde(skip)]
@@ -108,7 +108,7 @@ pub struct ChatResponseData {
     pub id: String,
     pub choices: Vec<ChoiceData>,
     pub created: u32,
-    pub model: ModelID,
+    pub model: ModelId,
     #[serde(default)]
     pub system_fingerprint: String,
     pub usage: UsageData,
@@ -136,7 +136,7 @@ pub struct ChatResponseChunkData {
     pub id: String,
     pub choices: Vec<ChunkChoiceData>,
     pub created: u32,
-    pub model: ModelID,
+    pub model: ModelId,
     pub system_fingerprint: String,
 
     #[serde(default = "response_chunk_object")]

--- a/moly-protocol/src/open_ai.rs
+++ b/moly-protocol/src/open_ai.rs
@@ -158,11 +158,11 @@ pub enum ChatResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModelsResponse {
     pub object: String,
-    pub data: Vec<OpenAIModel>,
+    pub data: Vec<OpenAiModel>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OpenAIModel {
+pub struct OpenAiModel {
     pub id: String,
     pub object: String,
     pub created: u32,

--- a/moly-protocol/src/protocol.rs
+++ b/moly-protocol/src/protocol.rs
@@ -7,12 +7,12 @@ use std::sync::mpsc::Sender;
 
 #[derive(Debug, Deserialize)]
 pub struct StartDownloadRequest {
-    pub file_id: FileID,
+    pub file_id: FileId,
 }
 
 #[derive(Clone, Debug)]
 pub enum FileDownloadResponse {
-    Progress(FileID, f32),
+    Progress(FileId, f32),
     Completed(DownloadedFile),
 }
 
@@ -46,14 +46,14 @@ pub struct LoadModelOptions {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LoadModelRequest {
-    pub file_id: FileID,
+    pub file_id: FileId,
     pub options: LoadModelOptions,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LoadedModelInfo {
-    pub file_id: FileID,
-    pub model_id: ModelID,
+    pub file_id: FileId,
+    pub model_id: ModelId,
 
     // The port where the local server is listening for the model.
     // if 0, the server is not running.
@@ -71,7 +71,7 @@ pub struct ModelResourcesInfo {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LoadModelResponse {
-    Progress(FileID, f32),
+    Progress(FileId, f32),
     Completed(LoadedModelInfo),
     ModelResourcesUsage(ModelResourcesInfo),
 }
@@ -127,15 +127,15 @@ pub enum Command {
     // The argument is a string with the keywords to search for.
     SearchModels(String, Sender<Result<Vec<Model>>>),
 
-    DownloadFile(FileID, Sender<Result<FileDownloadResponse>>),
-    PauseDownload(FileID, Sender<Result<()>>),
-    CancelDownload(FileID, Sender<Result<()>>),
-    DeleteFile(FileID, Sender<Result<()>>),
+    DownloadFile(FileId, Sender<Result<FileDownloadResponse>>),
+    PauseDownload(FileId, Sender<Result<()>>),
+    CancelDownload(FileId, Sender<Result<()>>),
+    DeleteFile(FileId, Sender<Result<()>>),
 
     GetCurrentDownloads(Sender<Result<Vec<PendingDownload>>>),
     GetDownloadedFiles(Sender<Result<Vec<DownloadedFile>>>),
 
-    LoadModel(FileID, LoadModelOptions, Sender<Result<LoadModelResponse>>),
+    LoadModel(FileId, LoadModelOptions, Sender<Result<LoadModelResponse>>),
 
     // Eject currently loaded model, if any is provided
     EjectModel(Sender<Result<()>>),

--- a/moly-protocol/src/protocol.rs
+++ b/moly-protocol/src/protocol.rs
@@ -24,7 +24,7 @@ pub enum ContextOverflowPolicy {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum GPULayers {
+pub enum GpuLayers {
     Specific(u32),
     Max,
 }
@@ -33,7 +33,7 @@ pub enum GPULayers {
 pub struct LoadModelOptions {
     pub override_server_address: Option<String>,
     pub prompt_template: Option<String>,
-    pub gpu_layers: GPULayers,
+    pub gpu_layers: GpuLayers,
     pub use_mlock: bool,
     pub n_batch: Option<u32>,
     pub n_ctx: Option<u32>,


### PR DESCRIPTION
Writing acronyms in all upper case is a human language thing that doesn't translate well to camel case. See the following examples:

- `XMLHttpRequest` (from JS).
  - Yes, it's inconsistent, but writing the acronyms all in uppercase would look like `XMLHTTPRequest`, which is worst.
- `OpenAIImage` (from Moly)
  - That `II` is difficult to read.
  - Also, `A` at the beginning and `I` at the end are term starters, while the `I` in the middle is written with the same casing without meaning anything special.
  
For writing consistent camel case, uppercase should be used as term separators (no matter if the term is a word or an acronym).